### PR TITLE
ERROR: LoadError: use `include` instead of `reload` to load source files

### DIFF
--- a/src/watch.jl
+++ b/src/watch.jl
@@ -45,13 +45,13 @@ function julieTest()
   function runAllTest() 
     for file in readdir(joinpath(PWD,"test"))
       isTestFile(file) || continue
-      reload(joinpath(PWD, "test", file)) 
+      include(joinpath(PWD, "test", file)) 
     end
     JulieTest.runTests()
   end
 
   function runSingleTest(filepath::String)
-    reload(filepath)
+    include(filepath)
     JulieTest.runTests()
   end
 


### PR DESCRIPTION
In Julia 0.4 we need to use include instead of reload.