### PR TITLE
Added support for Parameterised Tests

### DIFF
--- a/src/JulieTest.jl
+++ b/src/JulieTest.jl
@@ -3,17 +3,17 @@ module JulieTest
 include("JulieTest/context.jl")
 include("JulieTest/is.jl")
 
-export 
+export
   # reporter
   typeReport,
-  
+
   #context
   describe, _describe, it, iit, _it,
-  
+
   # @is
   @is,
   falsy, falsey, truthy, not,
-  
+
   # comparision
   least, atleast, atLeast,
   most, ismost, isMost,
@@ -22,18 +22,18 @@ export
 
   # array
   empty,
-  
+
   # macros
   @p, @l, @d, @pp, @s
-  
+
 reporterLoaded = false
 
 function runTests()
-  global reporterLoaded 
+  global reporterLoaded
   reporterLoaded || reporter("spec")
   run()
 end
-  
+
 function reporter(str::String)
   global reporterLoaded = true
   str == "" && return

--- a/src/JulieTest/context.jl
+++ b/src/JulieTest/context.jl
@@ -12,12 +12,16 @@ type Test
   name::String
   desc::Description
   fn::Function
+  data::Tuple
   iit::Bool
   function Test(name::String, desc::Description, fn::Function, iit::Bool)
-    new(name,desc,fn,iit)
+    new(name,desc,fn,(),iit)
+  end
+  function Test(name::String, desc::Description, fn::Function, data::Tuple)
+    new(name,desc,fn,data,false)
   end
   function Test(name::String, desc::Description, fn::Function)
-    new(name,desc,fn,false)
+    new(name,desc,fn,(),false)
   end
 end
 
@@ -47,7 +51,7 @@ function run(test::Test)
   fin = 0
   try
     t0 = time()
-    test.fn()
+    test.fn(test.data...)
     fin = time() - t0
   catch e
     err = Error(test,e,catch_backtrace())
@@ -84,7 +88,7 @@ function run()
   t0 = time()
   run(descriptions)
   summaryReport(passes,errors, toMilis(time() - t0))
-  
+
   # Reset the global variables
   tests = None
   depth = 0
@@ -93,7 +97,7 @@ function run()
   empty!(passes)
   empty!(errors)
   currDesc = descriptions
-  
+
   println('\n',"\033[33mAll test finished running\n", RESET)
   return length(errors)
 end
@@ -107,11 +111,20 @@ function it(fn::Function, name::String)
   push!(currDesc.children, Test(name,currDesc,fn))
 end
 
+function it(fn::Function, name::String, cases::Any)
+  it(fn, name, cases...)
+end
+
+function it(fn::Function, name::String, cases::Tuple...)
+  for row in cases
+    push!(currDesc.children, Test("$name : $row",currDesc,fn,row))
+  end
+end
+
 function iit(fn::Function, name::String)
   global iitOn = true
   push!(currDesc.children, Test(name,currDesc,fn,true))
 end
-  
+
 _describe(args...) = begin end
 _it(args...) = begin end
-

--- a/src/watch.jl
+++ b/src/watch.jl
@@ -45,13 +45,13 @@ function julieTest()
   function runAllTest() 
     for file in readdir(joinpath(PWD,"test"))
       isTestFile(file) || continue
-      reload(joinpath(PWD, "test", file)) 
+      include(joinpath(PWD, "test", file)) 
     end
     JulieTest.runTests()
   end
 
   function runSingleTest(filepath::String)
-    reload(filepath)
+    include(filepath)
     JulieTest.runTests()
   end
 

--- a/test/JuliaTest_test.jl
+++ b/test/JuliaTest_test.jl
@@ -8,11 +8,11 @@ describe("@is") do
   it("basic") do
     @is 1 => 1
   end
-  
+
   it("expression on left side") do
     @is 1 + 1 => 2
   end
-  
+
   it("variable on the left side") do
     x = 1
     @is x => 1
@@ -51,8 +51,17 @@ describe("@is") do
     x = []
     @is x => empty
   end
-  
-  
+
+  describe("parameterised tests") do
+    it("runs each case the given 2 values", [(2, 4) (1,1)]) do base, answer
+      @is base^2 => answer
+    end
+
+    it("runs each case containing multiple values", [(2, 3, 5) (1,2,3) (-1,2,1)]) do first, second, answer
+      @is first + second => answer
+    end
+  end
+
   describe("recursive describe") do
     it(noob, "in recursive")
     describe("going deeper") do
@@ -69,15 +78,15 @@ describe("condition function") do
     @is x => atleast 2
     @is x => atLeast 2
   end
-  
+
   it("not") do
     @is 1 => not 2
-    
+
   it("double not") do
     @is 1 => not not 1
   end
   end
-  
+
   it("built-in isa") do
     @is 1 => isa Number
   end


### PR DESCRIPTION
If we need to run the same tests for different sets of data, we can simply pass an array of tuples.

Example
```
  describe("parameterised tests") do
    it("runs each case the given 2 values", [(2, 4) (1,1)]) do base, answer
      @is base^2 => answer
    end

    it("runs each case containing multiple values", [(2, 3, 5) (1,2,3) (-1,2,1)]) do first, second, answer
      @is first + second => answer
    end
  end
```
Results
```
    parameterised tests
      ✓ runs each case the given 2 values : (2,4) (4ms)
      ✓ runs each case the given 2 values : (1,1)
      ✓ runs each case containing multiple values : (2,3,5) (4ms)
      ✓ runs each case containing multiple values : (1,2,3)
      ✓ runs each case containing multiple values : (-1,2,1)
```